### PR TITLE
Avoid random sort of legend

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -38,7 +38,7 @@ c3_chart_internal_fn.getTooltipContent = function (d, defaultTitleFormat, defaul
             return orderAsc ? v1 - v2 : v2 - v1;
         });
     } else {
-        var ids = $$.orderTargets($$.data.targets).map(function (i) {
+        var ids = $$.orderTargets($.extend(true, [], $$.data.targets)).map(function (i) {
             return i.id;
         });
         d.sort(function(a, b) {


### PR DESCRIPTION
Accidentally order of legend are changed, when we create a graph which both of tooltip and legend are enabled.
To avoid this behavior, we pass deep copy of "$$.data.targets" to orderTargets().